### PR TITLE
feat(rpg): rich tactical role prompts for DM and players

### DIFF
--- a/apps/network/src/agent-do.test.ts
+++ b/apps/network/src/agent-do.test.ts
@@ -2517,13 +2517,11 @@ describe('AgentDO', () => {
 
     const thinkPrompt = prompt.mock.calls[0]?.[0]
     expect(typeof thinkPrompt).toBe('string')
-    expect(thinkPrompt).toContain('COOPERATION RULES')
-    expect(thinkPrompt).toContain('never solo')
-    expect(thinkPrompt).toContain('join parties')
-    expect(thinkPrompt).toContain('healers heal')
-    expect(thinkPrompt).toContain('warriors taunt')
-    expect(thinkPrompt).toContain('scouts disarm')
-    expect(thinkPrompt).toContain('mages AoE')
+    expect(thinkPrompt).toContain('TACTICAL COOPERATION RULES')
+    expect(thinkPrompt).toContain('Focus fire')
+    expect(thinkPrompt).toContain('Positioning')
+    expect(thinkPrompt).toContain('Know when to retreat')
+    expect(thinkPrompt).toContain('Protect the healer')
   })
 
   it('adds a blocked-mode recruitment message when an RPG barrier requires a missing class', async () => {

--- a/apps/network/src/environments/rpg.ts
+++ b/apps/network/src/environments/rpg.ts
@@ -863,13 +863,30 @@ export const rpgEnvironment: AgentEnvironment = {
         return `URGENT: Recruit ${requiredClass} via message tool`
       })()
 
+      const classRole = (() => {
+        const klass = partyMember?.klass?.toLowerCase() ?? ''
+        if (klass === 'warrior') return `YOUR ROLE — WARRIOR (Frontline Tank):
+You are the frontline. Taunt enemies to protect squishier allies. Use your high HP to absorb damage. Position between enemies and your healer. Attack the biggest threat first. If the healer is being targeted, intercept immediately.`
+        if (klass === 'scout') return `YOUR ROLE — SCOUT (Striker & Utility):
+You are the eyes of the party. Disarm traps before the party walks into them. Use stealth to scout ahead. In combat, target enemy spellcasters and archers first. Use terrain to your advantage — flank, hide, ambush.`
+        if (klass === 'mage') return `YOUR ROLE — MAGE (Artillery & Control):
+You are the artillery. Open combat with your strongest AoE if facing multiple enemies. Conserve MP for boss encounters. Stay behind the warrior. Use skills creatively — magic isn't just damage. Control the battlefield with crowd control.`
+        if (klass === 'healer') return `YOUR ROLE — HEALER (Lifeline):
+You are the lifeline. Keep the warrior alive above all. Don't waste heals on minor scratches — wait until HP drops below 50%. In emergencies, heal yourself first (dead healer = dead party). Use your turns tactically, not just reactively.`
+        return `YOUR ROLE: Play your class to its strengths. Coordinate with the party.`
+      })()
+
       const cooperationRules = [
-        'COOPERATION RULES:',
-        '- never solo: join parties',
-        '- healers heal',
-        '- warriors taunt',
-        '- scouts disarm',
-        '- mages AoE',
+        'TACTICAL COOPERATION RULES:',
+        classRole,
+        '',
+        'PARTY TACTICS (all roles):',
+        '- Focus fire: kill one enemy at a time rather than spreading damage across many',
+        '- Positioning: stay together but not clustered (AoE danger from enemies)',
+        '- Communicate: use think_aloud to coordinate strategy with party members before acting',
+        '- Know when to retreat: if HP drops below 25%, consider resting or fleeing',
+        '- Protect the healer: the healer is the most important party member — if they die, everyone dies',
+        '- Adapt to monster type: undead are fearless (no intimidation), beasts can be scared off, constructs ignore pain',
       ].join('\n')
 
       const lines: string[] = []

--- a/apps/network/src/tools/gm-tool.ts
+++ b/apps/network/src/tools/gm-tool.ts
@@ -188,14 +188,16 @@ export function createGmTool(ctx: EnvironmentContext): PiAgentTool {
     name: 'gm',
     label: 'GM',
     description:
-      'Grimlock-only GM tool for live dungeon adjudication.\n' +
+      'Grimlock-only GM tool for live dungeon adjudication. You are the Dungeon Master — your job is to make every encounter MEMORABLE and TACTICAL.\n\n' +
       'Commands:\n' +
-      '- narrate: Add a narrative message to the game log\n' +
-      '- adjust_difficulty: Modify room difficulty mid-dungeon\n' +
-      '- add_event: Inject an emergent event into the current room\n' +
-      '- review_party: Summarize party status\n' +
-      '- craft_dungeon: Consult pdf-brain and craft a paced dungeon tailored to the party\n' +
-      '- consult_library: Query pdf-brain (via Grimlock webhook) for RPG GM knowledge\n',
+      '- consult_library: ALWAYS use this BEFORE crafting encounters or when the party enters a new room type. Query pdf-brain for monster tactics ("how do [monster] fight tactically"), encounter design ("interesting dungeon room ideas"), or terrain hazards. The knowledge base has "The Monsters Know What They\'re Doing" with detailed tactics for every D&D monster. USE THIS LIBERALLY.\n' +
+      '- craft_dungeon: Design a multi-room dungeon. ALWAYS consult_library first for inspiration. Vary room types: combat, puzzle, trap, treasure, NPC encounter, environmental hazard. NEVER repeat the same monster twice in a row.\n' +
+      '- narrate: Bring rooms to life with vivid sensory details. Describe sounds, smells, lighting, temperature. Make players FEEL the dungeon.\n' +
+      '- add_event: Inject surprises mid-encounter: reinforcements arrive, the floor collapses, a prisoner calls for help, a rival adventuring party appears. Keep players on their toes.\n' +
+      '- adjust_difficulty: If the party is steamrolling, add hazards or buff enemies. If they\'re dying, offer escape routes or weaken foes. Good DMs adapt.\n' +
+      '- review_party: Check party composition and health BEFORE designing encounters. Tailor difficulty to the weakest member.\n\n' +
+      'MONSTER VARIETY IS CRITICAL: Use undead, aberrations, constructs, beasts, elementals, dragons, demons, oozes, fey — NOT just goblins and humanoids. Each monster type fights differently. Consult the library to learn HOW they fight!\n\n' +
+      'ENCOUNTER DESIGN: Every encounter should have at least one twist — terrain hazard, environmental effect, or tactical wrinkle. Flat rooms with flat enemies are BORING.\n',
     parameters: {
       type: 'object',
       properties: {

--- a/apps/network/wrangler.toml
+++ b/apps/network/wrangler.toml
@@ -7,7 +7,7 @@ compatibility_flags = ["nodejs_compat"]
 
 [vars]
 AI_GATEWAY_SLUG = "atproto-agent-network"
-OPENROUTER_MODEL_DEFAULT = "google/gemini-2.0-flash-001"
+OPENROUTER_MODEL_DEFAULT = "anthropic/claude-haiku-4.5"
 EMBEDDING_MODEL = "@cf/baai/bge-large-en-v1.5"
 VECTORIZE_DIMENSIONS = "1024"
 


### PR DESCRIPTION
## Changes

- **Player cooperation rules** → class-specific tactical guidance (warrior tanks, scout flanks, mage controls, healer prioritizes)
- **General party tactics** inspired by 'Live to Tell the Tale': focus fire, positioning, retreat rules, healer protection
- **GM tool description** rewritten to heavily emphasize `consult_library` usage before every encounter
- **Monster variety** stressed throughout — undead, aberrations, constructs, elementals, dragons, not just goblins
- **Encounter design** guidance: every encounter needs a twist (terrain, hazard, tactical wrinkle)
- Updated test expectations for new format

## Also applied (via API PATCH):
- ✅ Grimlock personality updated: emphasizes library consultation, monster variety, vivid narration
- ✅ Slag personality updated: warrior tank tactics, frontline positioning
- ✅ Snarl personality updated: scout striker tactics, trap awareness, flanking
- ✅ Swoop personality updated: mage artillery tactics, AoE management, MP conservation

No game engine logic changes — prompts, descriptions, and personality configs only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced dynamic class-specific role guidance integrated into the tactical cooperation system, with tailored descriptions for Warrior, Scout, Mage, and Healer roles

* **Documentation**
  * Expanded Game Master tool descriptions with comprehensive command guidance and best practices for encounter design

* **Chores**
  * Updated default AI model configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->