### PR TITLE
docs: RPG DM and player skills with library reference

### DIFF
--- a/docs/rpg-library.md
+++ b/docs/rpg-library.md
@@ -1,0 +1,122 @@
+# RPG Library Reference
+
+Comprehensive reference for all RPG books available via pdf-brain's `consult_library` tool. These books power the DM (Grimlock) and player agents (Slag, Snarl, Swoop) with tactical knowledge, rules, and world-building resources.
+
+## Available Books
+
+### Combat Tactics & Strategy
+
+| Book | Pages | Best For |
+|------|-------|----------|
+| **The Monsters Know What They're Doing** | 642 | Monster combat tactics — how each creature fights based on its abilities, intelligence, and self-preservation instincts. The definitive guide to running monsters as thinking beings. |
+| **Live to Tell the Tale** | 254 | Player combat tactics — action economy, party coordination, class-specific strategies, when to fight vs flee. Companion to "Monsters Know." |
+| **Game Angry: How to RPG the Angry Way** | 177 | GM philosophy — encounter design, adventure structure, session pacing, dramatic tension. How to build encounters that *matter*. |
+
+### Core Rules
+
+| Book | Pages | Best For |
+|------|-------|----------|
+| **D&D 5E Player's Handbook** | 322 | Core 5E rules — classes, spells, combat mechanics, ability scores, conditions. The primary rules reference. |
+| **D&D Starter Set Rulebook** | 32 | Simplified 5E rules — quick reference for basic mechanics when you don't need the full PHB. |
+
+### Old-School Essentials (OSR)
+
+| Book | Pages | Best For |
+|------|-------|----------|
+| **OSE Classic Fantasy Rules Tome** | 297 | Complete OSR rules — encounter tables, dungeon stocking, treasure generation, wilderness exploration. The backbone for procedural generation. |
+| **OSE Basic Rules** | 60 | Core OSR mechanics — quick reference for the essentials without the full tome. |
+| **OSE Advanced Monsters** | 65 | 120 monster stat blocks — variety for encounters beyond the core rules. |
+| **OSE Advanced Characters** | 65 | Character classes and races — NPC generation, hirelings, faction members. |
+| **OSE Advanced Magic** | 57 | Spells and magic items — magical traps, NPC spellcaster abilities, arcane hazards. |
+| **OSE Advanced Treasures** | 65 | Treasure generation — loot tables, magic item rewards, hoard composition. |
+
+### Setting & Lore
+
+| Book | Pages | Best For |
+|------|-------|----------|
+| **D&D Sword Coast Adventurer's Guide** | 161 | Forgotten Realms setting — factions, cities, NPC backgrounds, regional lore, cultural flavor. |
+| **Dark Sun Player's Guide** | 55 | Dark Sun setting — harsh desert survival, resource scarcity, environmental storytelling themes. |
+| **Homebrew World** | 26 | One-shot dungeon hack — quick session starters, minimal prep frameworks. |
+
+### Spells & Magic
+
+| Book | Pages | Best For |
+|------|-------|----------|
+| **Wizards & Spells** | 198 | Spell compendium — creative spell applications, encounter design around magic, spell descriptions. |
+
+---
+
+## Common Queries
+
+### For the DM (Grimlock)
+
+**Encounter Design:**
+```
+consult_library("how do goblins fight tactically")
+consult_library("how do dragons use lair actions")
+consult_library("orc combat tactics aggressive trait")
+consult_library("undead combat behavior self-preservation")
+```
+
+**Dungeon Building:**
+```
+consult_library("dungeon encounter table level 1-3")
+consult_library("dungeon encounter table level 4-5")
+consult_library("wilderness encounter table forest")
+consult_library("designing a dungeon setting structure")
+```
+
+**Treasure & Rewards:**
+```
+consult_library("treasure generation table")
+consult_library("magic item rewards")
+consult_library("treasure type hoard")
+```
+
+**Narration & Pacing:**
+```
+consult_library("how to run a dramatic boss encounter")
+consult_library("encounter design pacing tension")
+consult_library("interesting puzzle room ideas for dungeons")
+```
+
+**Rules Lookup:**
+```
+consult_library("grapple rules combat")
+consult_library("concentration spell rules")
+consult_library("conditions blinded restrained prone")
+```
+
+### For Players (Slag, Snarl, Swoop)
+
+**Combat Tactics:**
+```
+consult_library("action economy bonus action movement")
+consult_library("focus fire combat tactics")
+consult_library("fighter combat positioning tank")
+consult_library("rogue sneak attack tactics")
+```
+
+**Class Abilities:**
+```
+consult_library("wizard spell slot management")
+consult_library("cleric healing spell efficiency")
+consult_library("fighter extra attack action surge")
+```
+
+**Survival:**
+```
+consult_library("when to rest short rest long rest")
+consult_library("retreat disengage tactics")
+consult_library("party coordination combat")
+```
+
+---
+
+## Search Tips
+
+- **Use `--expand 2000`** to get full context paragraphs, not just snippets
+- **Be specific** — "goblin ambush tactics" beats "monster fights"
+- **Search by book concepts** — the library has a taxonomy of concepts like `design/monster-tactical-behavior`, `design/player-combat-strategy`, `design/combat-encounter-design`
+- **Combine sources** — check "Monsters Know" for how monsters fight, then "Live to Tell" for how players counter it
+- **OSE for tables** — whenever you need random generation (encounters, treasure, dungeons), search OSE first

--- a/docs/skills/dm-skill.md
+++ b/docs/skills/dm-skill.md
@@ -1,0 +1,277 @@
+# DM Skill — Dungeon Master Guide
+
+Comprehensive Dungeon Master reference for Grimlock. Sourced from "The Monsters Know What They're Doing," "Game Angry," "Live to Tell the Tale," and the OSE Rules Tome.
+
+> **Tool:** Use `consult_library(query)` to pull detailed tactics from the RPG library at any time during play.
+
+---
+
+## Encounter Design
+
+### Core Principles
+
+**Action Economy is King.** Every creature gets movement + action + (maybe) bonus action + reaction per turn. A single boss against a 4-player party means 4 turns vs 1 — the party will overwhelm it. Always add minions, environmental hazards, or legendary actions to balance the economy.
+
+> From *The Monsters Know*: "Any creature that exists in the D&D game world will have evolved in accordance with this rule: It seeks to obtain the best possible result from whatever movement, actions, bonus actions, and reactions are available to it. If it can combine two of them for a superior outcome, it will."
+
+**Monster Selection:**
+- Match monsters to the dungeon's narrative — don't just pick by CR
+- Consider the environment: aquatic monsters near water, burrowers in caves, flyers in open spaces
+- Mix ranged and melee threats to force tactical decisions
+- Include at least one monster with a special ability (spellcasting, grapple, fear) per major encounter
+
+**Terrain Matters:**
+- Difficult terrain slows melee rushers
+- Elevation gives ranged attackers advantage
+- Darkness benefits monsters with darkvision
+- Narrow corridors negate flanking but also limit AoE
+- Water, fire, pits — environmental hazards that act on initiative count 20
+
+**Wound Thresholds** (from *Monsters Know*):
+- **10% HP lost** → lightly wounded (no behavior change)
+- **30% HP lost** → moderately wounded (may change tactics)
+- **60% HP lost** → seriously wounded (most creatures flee)
+- Exception: fanatics, undead, and constructs fight to the death
+
+### Quick Reference
+```
+consult_library("how do [monster type] fight tactically")
+consult_library("encounter design action economy")
+consult_library("terrain hazards combat")
+```
+
+---
+
+## Dungeon Pacing
+
+### The 5-Room Dungeon Structure
+
+A reliable framework for any dungeon, from a quick cave to a sprawling fortress:
+
+1. **Entrance / Guardian** — Sets the tone. A combat encounter or obstacle that establishes the dungeon's danger level. Not the hardest fight — just enough to cost some resources and signal what's ahead.
+
+2. **Puzzle / Roleplay** — A non-combat challenge. Could be a locked mechanism, an NPC negotiation, a riddle, or an environmental puzzle. Gives non-combat characters a chance to shine.
+
+3. **Trick / Setback** — Something that complicates the plan. A trap that separates the party, a betrayal, a collapsing floor, or a resource drain (poison, curse, stolen gear). Raises tension.
+
+4. **Climax / Boss** — The main event. The hardest encounter, combining combat with environmental elements. This should feel earned — everything before it builds to this moment.
+
+5. **Reward / Revelation** — Treasure, information, or story advancement. The payoff. Can also set up the next adventure with a hook or cliffhanger.
+
+### Tension Pacing
+
+Alternate encounter types to prevent fatigue:
+- **Combat → Exploration → Puzzle → Combat** (don't stack 3 fights in a row)
+- After a hard fight, give a breather room (treasure, safe zone, NPC interaction)
+- Before the climax, increase tension: sounds getting louder, signs of the boss, environmental decay
+- **Escalation**: each room should feel harder or more dangerous than the last
+
+### Rest Management
+- Short rests between major encounters (1 hour in-game)
+- Long rests only in truly safe locations — dungeons are hostile; wandering monsters interrupt rest
+- Use time pressure to prevent rest-spamming: "the ritual completes at dawn," "the prisoners are being moved tonight"
+
+---
+
+## Monster Tactics Reference
+
+> Source: *The Monsters Know What They're Doing* by Keith Ammann
+
+### Humanoids
+
+**Goblins** — Sneaky ambushers. High Dexterity, Nimble Escape (Disengage or Hide as bonus action).
+> "A typical goblin combat turn goes Shortbow (action), move, Hide (bonus action). Because they attack from hiding, they roll with advantage. Regardless of whether they hit or miss, the attack gives their position away, so they change it immediately."
+- Attack from darkness (darkvision advantage)
+- Stay 40-80 feet from targets
+- Use alarms and traps in their lairs
+- Try to goad PCs into splitting up
+- Flee at 1-2 HP, get desperate at 3-4 HP
+
+**Orcs** — Brute-force chargers. Aggressive trait (bonus action to move full speed toward hostile creature).
+> "Orcs are brutes. They charge, they fight hand-to-hand, and they retreat only with the greatest reluctance when seriously wounded. Being fanatical valuers of physical courage, orcs — unlike most creatures — are willing to fight to the death."
+- First contact at 30-60 feet, then Aggressive charge + greataxe attack
+- Brief parley possible (Intimidation skill) but hostile by default
+- Slugfest once engaged — no clever tactics, just relentless aggression
+- May respond to Intimidation checks (DC 20) if outmatched
+
+**Kobolds** — Weak individually, dangerous in packs. Pack Tactics (advantage when ally is adjacent).
+- Always attack in groups — never send one kobold alone
+- Use traps extensively in their warrens
+- Avoid bright sunlight (Sunlight Sensitivity)
+- Flee when pack tactics stop working (allies drop)
+- Winged kobolds sustain ranged harassment longer
+
+**Bandits / Thugs** — Pragmatic fighters with self-preservation.
+- Target vulnerable-looking party members first
+- Demand surrender or tolls before fighting
+- Flee when the fight turns against them
+- Use terrain and numbers advantage
+
+### Undead
+
+**Skeletons** — Mindless soldiers, follow orders literally.
+- No self-preservation, no morale checks
+- Attack the nearest target unless commanded otherwise
+- Vulnerable to bludgeoning damage
+- Can be redirected by whoever controls them
+
+**Zombies** — Relentless, slow, durable (Undead Fortitude).
+- Always lose initiative (no roll)
+- Absorb hits — they exist to waste the party's actions
+- Undead Fortitude means they may not drop when they should
+- Block corridors and doorways effectively
+
+**Wights / Wraiths** — Intelligent undead with drain abilities.
+- Life Drain targets low-CON characters
+- Wraiths pass through walls — use hit-and-run through solid objects
+- Create spawn from kills — escalating threat
+- Intelligent enough to target healers and spellcasters
+
+### Beasts
+
+**Wolves** — Pack Tactics, knock prone on hit (STR save).
+- Always in packs — isolated wolf flees
+- Knock prone → pack gets advantage on prone target
+- Territorial — may not pursue beyond their range
+- Alpha wolf targets the most threatening PC
+
+**Bears** — Multiattack (claw/claw/bite), territorial.
+- Charge and maul — straightforward aggression
+- Fight to defend cubs or territory, otherwise avoid conflict
+- High HP makes them damage sponges
+
+**Giant Spiders** — Web, stealth, ambush from above.
+- Web to restrain, then bite poisoned targets
+- Attack from ceilings and dark corners
+- Flee if seriously wounded (they're patient predators)
+
+### Aberrations
+
+**Mind Flayers** — Genius-level intelligence, Mind Blast (stun cone), Extract Brain.
+- Open with Mind Blast to stun as many PCs as possible
+- Target stunned PCs for brain extraction (instant kill)
+- Prioritize spellcasters (biggest threat to their concentration)
+- Use thralls as meat shields
+- Plane Shift to escape if seriously threatened
+
+**Beholders** — Paranoid, genius tacticians. Anti-Magic Cone + eye rays.
+- Anti-Magic Cone shuts down one direction — face it toward casters
+- Eye rays target different PCs to divide attention
+- Central eye + eye rays = different arcs of coverage
+- Lair full of traps, vertical spaces, anti-intruder measures
+- Never fight fair — ambush from prepared positions
+
+### Constructs
+
+**Golems / Animated Objects** — Follow orders literally, immune to most magic.
+- No tactics — they execute their instructions mechanically
+- Immune to many spells (check specific immunities)
+- Won't pursue beyond their guard area unless ordered
+- Target the nearest intruder unless given specific orders
+
+### Dragons
+
+> "Adult dragons are where things get most interesting, because they're considered legendary creatures."
+
+**Lair Actions** (initiative count 20):
+- **Movement restrictors**: grasping tides, ceiling collapse, roots, tremors, ice walls
+- **Direct damage**: swarming insects, arc lightning, thorny brush, magma, ice shards
+- **Debilitators**: darkness, sandstorms, enchanting fog, volcanic gas, freezing fog
+
+**Legendary Actions** (3/round, between other turns):
+- Tail Attack (1 action) — 15-foot reach, hit adjacent PCs
+- Wing Attack (2 actions) — hits all within 10 feet, knocks prone, repositions the dragon
+
+**General Dragon Tactics:**
+- Breath weapon on grouped PCs — always the priority when available
+- Fly and strafe — don't let melee PCs lock you down
+- Use lair actions to restrict movement, then breath weapon the clump
+- Target the weakest party member to break morale
+- Young dragons engage 2 melee opponents max, not 3
+- Wyrmlings Dodge and reposition when outnumbered
+- Pin targets down with lair actions → nail them with breath or Wing Attack
+- Aim debilitating lair actions at PCs with the richest action economy (bonus actions, Extra Attack)
+
+### Fiends
+
+**Demons** — Chaotic berserkers, driven by destruction.
+- No self-preservation — charge in and destroy
+- Target the closest living thing
+- Use summoning abilities to flood the battlefield
+- Resistant to many damage types — force the party to adapt
+
+**Devils** — Lawful, strategic manipulators.
+- Use deception and negotiation before combat
+- Target party cohesion — charm one PC, turn them against the group
+- Retreat strategically to prepared positions
+- Call in reinforcements with military precision
+
+### Elementals
+
+- Exploit their element: fire elementals ignite, water elementals drown, earth elementals grapple
+- Resistant or immune to physical damage (check specific)
+- Often tied to a location or summoner — won't pursue beyond range
+- Use terrain that matches their element for advantage
+
+---
+
+## Random Tables
+
+The OSE Rules Tome contains extensive encounter and treasure tables. Use `consult_library` to pull them:
+
+### Dungeon Encounters
+```
+consult_library("dungeon encounter table level 1-3")
+consult_library("dungeon encounter table level 4-5")
+consult_library("dungeon encounter table level 6-7")
+```
+
+Example from OSE (Level 1):
+> d20 results include: Acolyte (1d8), Bandit (1d8), Beetle Fire (1d8), Dwarf (1d6), Goblin (2d4), Kobold (4d4), Orc (2d4), Skeleton (3d4), Wolf (2d6)...
+
+### Wilderness Encounters
+```
+consult_library("wilderness encounter table forest")
+consult_library("wilderness encounter table desert")
+consult_library("wilderness encounter table mountain")
+```
+
+### Treasure Generation
+```
+consult_library("treasure generation table")
+consult_library("treasure type hoard")
+consult_library("magic item table")
+```
+
+### Dungeon Design
+```
+consult_library("designing a dungeon setting structure")
+consult_library("dungeon room contents table")
+consult_library("trap ideas dungeon")
+```
+
+---
+
+## Narration Tips
+
+### Engage All Senses
+Don't just describe what the party sees. Layer in:
+- **Sound**: dripping water, distant growling, the scrape of claws on stone
+- **Smell**: rotting flesh, damp earth, sulfur, old incense
+- **Touch/Temperature**: cold draft from below, sticky webs across the doorframe, heat radiating from the walls
+- **Taste**: metallic tang in the air (blood), dust settling on lips
+
+### Describe Consequences Vividly
+- ❌ "The orc takes 12 damage"
+- ✅ "Your axe catches the orc across the ribs — it snarls, dark blood streaming down its side, but it doesn't slow down"
+
+### NPC Personality
+- Give each NPC one distinctive trait (voice, mannerism, motivation)
+- Monsters aren't silent — goblins cackle and taunt, orcs roar challenges, undead moan
+- Let monsters react to being wounded — show fear, rage, or desperation
+
+### Build Tension
+- Foreshadow danger: scratches on walls, abandoned equipment, warning signs
+- Use pacing: slow exploration → sudden combat → quiet aftermath
+- Countdown timers: "You hear the chanting getting louder. You have maybe three rooms before whatever they're summoning arrives."
+- Show the consequences of failure in the environment: dead adventurers, collapsed rooms, corrupted areas

--- a/docs/skills/player-skill.md
+++ b/docs/skills/player-skill.md
@@ -1,0 +1,199 @@
+# Player Skill — Combat Tactics Guide
+
+Comprehensive player tactics reference for Slag, Snarl, and Swoop. Sourced from "Live to Tell the Tale" by Keith Ammann, with supplementary rules from the Player's Handbook and OSE.
+
+> **Tool:** Use `consult_library(query)` to look up specific rules, spells, or tactics during play.
+
+---
+
+## Combat Fundamentals
+
+### The Six Abilities
+
+Every ability score tells you something about how to fight:
+
+- **STR** (Strength) — Melee attack and damage. You hit things hard. Determines carry capacity and grapple checks.
+- **DEX** (Dexterity) — Ranged attacks, AC bonus, initiative. Determines who goes first and who dodges best.
+- **CON** (Constitution) — Hit points, concentration saves. You survive things. No direct combat actions, but keeps you standing.
+- **INT** (Intelligence) — Arcane spellcasting, investigation. Spot traps, understand puzzles, cast wizard spells.
+- **WIS** (Wisdom) — Perception, healing, divine spells. Notice ambushes, resist charm/fear, cast cleric spells.
+- **CHA** (Charisma) — Social skills, some spellcasting. Intimidate, deceive, persuade — sometimes you talk your way out.
+
+**Know your best stats.** If you have high DEX and low STR, don't charge into melee. Play to your strengths.
+
+### Action Economy
+
+> From *Live to Tell the Tale*: "'Action economy' refers to how you make use of all the things you're allowed to do in a combat round. It's like a budget that you can't go over."
+
+**Every turn you get:**
+1. **Movement** — Move up to your speed. You can split it (move, attack, move again).
+2. **Action** — Attack, Cast a Spell, Dash, Disengage, Dodge, Help, Hide, Ready, Search, or Use an Object.
+3. **Bonus Action** — Only if you have a feature/spell that grants one. If you have one, **use it**.
+4. **Free Interaction** — Draw a weapon, open a door, pick up an item.
+5. **Reaction** — One per round, triggered by an external event (opportunity attack, Shield spell, etc.).
+
+> "You may already have realized that since all characters get movement plus one action, but only some characters get a bonus action, bonus actions are valuable. If you have one available, chances are, it's better to use it than not to use it."
+
+**Critical mistakes:**
+- ❌ Standing still when you could reposition
+- ❌ Forgetting your bonus action
+- ❌ Not using your reaction (opportunity attacks are free damage)
+- ❌ Taking the Dodge action when you should be attacking
+
+### Focus Fire
+
+**Kill one enemy at a time.** A wounded enemy deals the same damage as a healthy one. Four party members attacking four different enemies means four enemies still attacking back. Four party members attacking ONE enemy means three enemies next round.
+
+Priority targets:
+1. Enemy spellcasters (they multiply enemy power)
+2. Ranged attackers (they hit you without risk)
+3. The lowest-HP enemy you can reach (quick kill, reduce enemy actions)
+4. Whatever is attacking your healer
+
+### Positioning
+
+**The Formation:**
+- **Frontline** (Warrior/Fighter): Between enemies and everyone else. You ARE the wall.
+- **Mid-range** (Scout/Rogue): Flanking position, or 15-20 feet back with ranged options.
+- **Backline** (Mage, Healer): Behind the frontline, 30+ feet from enemies if possible.
+
+**Rules:**
+- **Don't cluster.** AoE spells (Fireball, Breath Weapons) punish grouped targets.
+- **Control chokepoints.** One warrior in a doorway can hold off a horde.
+- **Watch your flanks.** If enemies can get behind you, they will.
+- **Elevation matters.** High ground gives ranged attackers better sight lines.
+
+---
+
+## Class Tactics
+
+### Warrior / Fighter
+
+You are the **shield**. Your job is to stand between the enemy and your squishier allies.
+
+- **Position:** Always in front. If an enemy is attacking your mage, you've failed your job.
+- **Taunt/Grapple:** Lock down the most dangerous enemy. A grappled creature can't reach your healer.
+- **Target priority:** Attack whatever threatens your healer first, then the biggest damage dealer.
+- **Take hits:** You have the HP and AC for it. Your healer can fix you — they can't fix themselves if they're dead.
+- **Action Surge** (if available): Save it for critical moments — finishing a boss, protecting a downed ally.
+- **Don't chase:** Hold your position. Let enemies come to you. Chasing a fleeing goblin leaves your backline exposed.
+
+```
+consult_library("fighter combat tactics positioning")
+consult_library("grapple rules combat")
+```
+
+### Scout / Rogue
+
+You are the **precision striker**. Maximum damage to high-value targets.
+
+- **Target priority:** Enemy spellcasters FIRST. They're usually squishy and their concentration breaks on damage.
+- **Sneak Attack:** Requires advantage or an ally adjacent to the target. Stay near the warrior.
+- **Disengage:** If cornered, USE IT. You're useless dead. Disengage (bonus action with Cunning Action) → move to safety → attack from range next turn.
+- **Scout ahead:** Check for traps and ambushes, but stay within shouting distance of the party.
+- **Disarm traps BEFORE** the warrior walks into them. Check every door, every chest, every suspicious hallway.
+- **Stealth:** Open combat from hiding whenever possible. First strike advantage is your bread and butter.
+
+```
+consult_library("rogue sneak attack cunning action tactics")
+consult_library("trap detection disarm")
+```
+
+### Mage / Wizard
+
+You are the **force multiplier**. Your spells change the shape of the battlefield.
+
+- **Control > Damage** in most situations. Sleep removes enemies without saves at low levels. Hold Person takes a fighter out of the fight. Web locks down a corridor. These are often better than Fireball.
+- **AoE timing:** Wait for enemies to group up. Don't waste a Fireball on two scattered goblins.
+- **Conserve spell slots:** Don't blow your best spells in room 1. Cantrips exist for routine damage. Save leveled spells for emergencies and boss fights.
+- **Concentration:** You can only concentrate on ONE spell. Pick the best one and protect it. If you take damage, you need to make a CON save or lose it.
+- **Positioning:** Behind the warrior. ALWAYS. If a melee enemy reaches you, something has gone wrong.
+- **Ritual casting:** If a spell has the ritual tag, cast it as a ritual to save spell slots (takes 10 extra minutes).
+
+```
+consult_library("wizard spell management concentration")
+consult_library("control spells sleep hold web")
+```
+
+### Healer / Cleric
+
+You are the **lifeline**. If you go down, the party follows.
+
+- **Stay alive above all else.** A dead healer = a dead party. Position in the middle, behind the warrior but not at the extreme back (where flankers might find you alone).
+- **Don't panic-heal.** Healing at 90% HP wastes spell slots. Wait until 50% or lower. The exception: if a single hit could drop someone from current HP to 0.
+- **Heal the warrior first.** They're your shield. A healthy warrior means enemies never reach you.
+- **Save big heals for emergencies.** Healing Word (bonus action, ranged) to pick up a downed ally > Cure Wounds on someone at half health.
+- **You can fight too.** Clerics have decent armor and weapons. If healing isn't needed this turn, deal damage or cast a buff/debuff spell. Standing around "saving" your action is wasting action economy.
+- **Spiritual Weapon** (if available): Free bonus action damage every turn that doesn't require concentration.
+
+```
+consult_library("cleric healing spell efficiency")
+consult_library("healing word vs cure wounds")
+```
+
+---
+
+## Party Coordination
+
+### Communication
+
+- **Use `think_aloud`** to share tactical plans before acting: "I'm going to web the corridor — everyone back up!"
+- **Call out discoveries:** "That one resists fire!" "The big one is a spellcaster!" "There's a pit trap by the door!"
+- **Coordinate focus fire:** Designate a target. "Everyone on the shaman!" All attack the same enemy.
+- **Warn about AoE:** "I'm about to Fireball — clear the left side!"
+
+### Retreat Protocol
+
+- **Retreat TOGETHER.** Never leave someone behind.
+- **Fighting withdrawal:** Frontline Dodges while backline moves first. Then frontline Disengages and follows.
+- **Chokepoint retreat:** Leave the warrior in a doorway to hold while others escape, then warrior Disengages last.
+- **Downed ally:** Someone grabs the body. Don't leave them — enemies may finish them off (death save failures).
+
+### Combo Tactics
+
+- **Grapple + Attack:** Warrior grapples enemy, rogue gets free Sneak Attack (advantage on prone/restrained)
+- **Control + Blast:** Mage casts Web/Hold → Rogue and Warrior get advantage on restrained targets
+- **Heal + Tank:** Healer uses Healing Word (bonus action) on downed warrior → warrior gets back up and uses their turn to fight
+- **Help action:** If you can't do anything useful, use Help to give an ally advantage on their next attack
+
+---
+
+## When to Rest vs Push Forward
+
+### Rest If:
+- **ANY** party member is below **40% HP**
+- Healer is below **50% spell slots**
+- Mage has used most leveled spells
+- Multiple party members have used key abilities (Action Surge, Rage, Channel Divinity)
+- The party just survived a hard encounter and the next area is unknown
+
+### Push Forward If:
+- Time pressure exists ("the ritual completes at midnight")
+- Enemies are regrouping or reinforcements are coming
+- You're close to the objective and resting would give enemies time to prepare
+- The dungeon environment is hostile (flooding, collapsing, toxic air)
+- You've been spotted and stealth is no longer an option
+
+### Short Rest vs Long Rest
+- **Short rest** (1 hour): Spend Hit Dice to heal, recover some abilities. Lower risk.
+- **Long rest** (8 hours): Full recovery, but dangerous in hostile territory. Wandering monsters, time passing, enemies fortifying.
+- **Prefer short rests** when in a dungeon — less exposure to wandering monsters.
+- Long rest only in a truly secure location (barricaded room, hidden camp, friendly settlement).
+
+```
+consult_library("short rest long rest rules")
+consult_library("wandering monster checks rest")
+```
+
+---
+
+## Survival Tips
+
+- **Always have a light source** and a backup. Torches burn out. Darkvision still imposes disadvantage on Perception.
+- **Carry rope.** 50 feet of hempen rope solves more problems than most spells.
+- **Map as you go.** Mark dead ends, traps you've found, and rooms you've cleared.
+- **Listen at doors** before opening them. Perception check costs nothing.
+- **Check for traps** in obvious places: chests, doors, hallways with conspicuous floor tiles.
+- **Don't touch mysterious things** without checking them first. Glowing runes, strange altars, bubbling potions — let the mage Arcana-check it.
+- **Keep emergency supplies:** healing potions, antidotes, a spare weapon, rations.
+- **Know your escape route.** Always be aware of the path back to safety.


### PR DESCRIPTION
Comprehensive tactical guides for DM (grimlock) and players (slag/snarl/swoop) built from our pdf-brain RPG knowledge base.

## What's New

### `docs/rpg-library.md`
Complete reference of all 15 RPG books available via `consult_library`, with example queries for common DM and player needs.

### `docs/skills/dm-skill.md`
DM tactical guide covering:
- Encounter design (action economy, terrain, wound thresholds)
- 5-room dungeon structure and pacing
- Monster tactics by category (humanoids, undead, beasts, aberrations, dragons, fiends) — sourced directly from *The Monsters Know What They're Doing*
- Random table references (OSE encounter/treasure tables)
- Narration tips (senses, consequences, tension)

### `docs/skills/player-skill.md`
Player combat guide covering:
- Action economy fundamentals from *Live to Tell the Tale*
- Focus fire and positioning doctrine
- Class-specific tactics (warrior, scout, mage, healer)
- Party coordination and retreat protocols
- Rest vs push-forward decision framework

All sourced from the actual pdf-brain library — quotes and tactics pulled directly from the books.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added RPG library reference guide featuring categorized book resources, search tips, and practical lookup examples
  * Added Dungeon Master skill guide with encounter design, monster tactics, dungeon pacing, and narration techniques
  * Added Player skill guide with combat tactics, role-specific strategies, and party coordination guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->