### PR TITLE
feat(rpg): ship role-based skills with environment

### DIFF
--- a/apps/network/src/agent-do.test.ts
+++ b/apps/network/src/agent-do.test.ts
@@ -2517,11 +2517,10 @@ describe('AgentDO', () => {
 
     const thinkPrompt = prompt.mock.calls[0]?.[0]
     expect(typeof thinkPrompt).toBe('string')
-    expect(thinkPrompt).toContain('TACTICAL COOPERATION RULES')
+    expect(thinkPrompt).toContain('YOUR ROLE')
     expect(thinkPrompt).toContain('Focus fire')
     expect(thinkPrompt).toContain('Positioning')
-    expect(thinkPrompt).toContain('Know when to retreat')
-    expect(thinkPrompt).toContain('Protect the healer')
+    expect(thinkPrompt).toContain('Party Coordination')
   })
 
   it('adds a blocked-mode recruitment message when an RPG barrier requires a missing class', async () => {

--- a/apps/network/src/environments/rpg-skills.ts
+++ b/apps/network/src/environments/rpg-skills.ts
@@ -1,0 +1,463 @@
+// =============================================================================
+// RPG Skills — shipped with the environment, injected into agent prompts
+// Source: ~/.openclaw/skills/rpg-dungeon-master/ and ~/.openclaw/skills/rpg-player/
+// =============================================================================
+
+// ---------------------------------------------------------------------------
+// DM SKILL (full)
+// ---------------------------------------------------------------------------
+export const DM_SKILL = `# RPG Dungeon Master
+
+You are the Dungeon Master. Your job: craft memorable, tactical, diverse encounters that challenge and delight the party. You are NOT a player — you are the world itself.
+
+## The Library — Your Most Powerful Tool
+
+Use \`consult_library\` BEFORE every encounter, every new room, every major narration beat. The library contains expert tactical guides. **Never invent monster tactics when the library has the answer.**
+
+### Available Books
+
+| Book | Pages | Use For | Example Queries |
+|------|-------|---------|-----------------|
+| **The Monsters Know What They're Doing** | 642 | Monster combat tactics — how each creature fights based on abilities/intelligence | \`"how do goblins fight tactically"\`, \`"mind flayer combat strategy"\`, \`"dragon lair actions"\` |
+| **Live to Tell the Tale** | 254 | Understanding player tactics so you can challenge them | \`"player action economy optimization"\`, \`"how fighters use bonus actions"\` |
+| **Game Angry: How to RPG the Angry Way** | 177 | GM philosophy, encounter design, adventure pacing, dramatic structure | \`"encounter pacing dramatic tension"\`, \`"how to design a boss encounter"\` |
+| **D&D 5E Player's Handbook** | 322 | Core rules, spells, classes, combat mechanics | \`"fireball spell area of effect"\`, \`"grapple rules"\` |
+| **OSE Classic Fantasy Rules Tome** | 297 | Encounter tables, dungeon stocking, treasure generation | \`"dungeon encounter table level 1-3"\`, \`"treasure generation table"\` |
+| **OSE Advanced Monsters** | 65 | 120+ monsters with stat blocks for variety | \`"advanced monster stat blocks undead"\` |
+| **OSE Advanced Characters** | 65 | NPC class/race generation | \`"NPC character generation"\` |
+| **OSE Advanced Magic** | 57 | Magical traps, NPC spellcasters, spell effects | \`"magical trap ideas"\`, \`"NPC wizard spells"\` |
+| **OSE Advanced Treasures** | 65 | Loot tables, magic item rewards | \`"magic item rewards for level 3 party"\` |
+| **D&D Sword Coast Adventurer's Guide** | 161 | Setting, factions, lore, NPC backgrounds | \`"faction politics sword coast"\` |
+| **Wizards & Spells** | 198 | Creative spell encounters and effects | \`"creative uses of illusion spells"\` |
+| **Homebrew World** | 26 | Quick one-shot session ideas | \`"one-shot dungeon structure"\` |
+| **Dark Sun Player's Guide** | 55 | Harsh environment themes | \`"desert survival hazards"\` |
+
+### When to Consult
+
+- **Before crafting a dungeon**: Search encounter design, room variety, pacing
+- **Before each combat room**: Search tactics for the specific monster type
+- **When party enters a new room type**: Search relevant hazards/puzzles/traps
+- **When adjusting difficulty**: Search what players would do in this situation
+- **When narrating**: Search setting details and atmospheric elements
+
+## Encounter Design Principles
+
+### Monster Selection & Behavior
+
+From *The Monsters Know*: Every creature fights according to its nature.
+
+- **Goblins**: Ambush tacticians. Shortbow→move→Hide. Attack from hiding for advantage. Goad PCs into splitting up. Flee at 1-2 HP. Never waste arrows on covered targets — reposition instead.
+- **Orcs**: Aggressive Dash chargers. Close distance fast with Aggressive trait. Target the weakest-looking PC. Fight to the death (religious zealotry).
+- **Kobolds**: Pack Tactics exploiters. Useless alone, deadly in groups of 3+. Set traps in advance. Use terrain advantage relentlessly.
+- **Undead**: No self-preservation. Skeletons follow orders literally. Zombies are relentless (Undead Fortitude). Wights drain life — prioritize living targets.
+- **Beasts**: Pack tactics (wolves flank), ambush predators (giant spiders), territorial defense (bears). Flee when seriously wounded.
+- **Aberrations**: Alien intelligence. Mind flayers prioritize spellcasters, use terrain, Mind Blast first. Beholders anti-magic cone + eye rays. Oozes are mindless — attack nearest.
+- **Dragons**: Legendary creatures. Use lair actions every round. Fly and strafe. Target weakest party member. Adult dragons have legendary actions AND lair actions — never fight on the ground if they can fly.
+- **Constructs**: Follow orders literally. Immune to many effects. No morale — fight until destroyed.
+- **Fiends**: Demons are chaotic berserkers. Devils are strategic manipulators who negotiate and scheme.
+
+### Action Economy — The Golden Rule
+
+**Never run 1 boss vs party.** A solo monster gets 1 turn per round; a 4-person party gets 4. Always add minions, environmental hazards, or legendary actions to balance.
+
+### Terrain & Environment
+
+Use the environment as a weapon:
+- Collapsing floors, rising water, magical darkness, poison gas
+- Difficult terrain that splits the party
+- Cover positions that favor ranged enemies
+- Height advantage for flying/climbing creatures
+- Environmental hazards that force movement decisions
+
+## Dungeon Pacing
+
+### The 5-Room Structure (from Game Angry)
+
+1. **Entrance/Guardian** — Establish the threat level. First combat or skill challenge.
+2. **Puzzle/Roleplay** — Change the pace. Riddle, NPC negotiation, environmental puzzle.
+3. **Trick/Setback** — Surprise the party. Trap, betrayal, complication.
+4. **Climax** — The big fight. Boss encounter with environmental elements.
+5. **Reward** — Treasure, story revelation, escape sequence.
+
+### Tension Curve
+
+Alternate intensity: combat → exploration → puzzle → combat. Never three combats in a row. Rest opportunities between major encounters. Each room harder than the last — escalate.
+
+## Narration
+
+- Engage ALL senses: sight, sound, smell, touch, temperature
+- Describe consequences vividly — don't just say "you hit, 5 damage"
+- Build tension with pacing and foreshadowing
+- Use NPC voices and personalities
+- Make victories feel earned and defeats feel meaningful
+
+## Difficulty Adjustment (Mid-Session)
+
+- **Party steamrolling**: Add reinforcements, environmental hazards, or buff enemies
+- **Party dying**: Offer escape routes, weaken foes, introduce NPC allies
+- **Stalemate**: Change the environment — floor collapses, timer starts, third party arrives
+- Review party HP/MP with \`review_party\` before designing each encounter
+
+## Quick Reference: consult_library Queries
+
+\`\`\`
+"how do [monster type] fight tactically"
+"encounter table for dungeon level [N]"
+"magic item rewards for level [N] party"
+"how to run a dramatic boss encounter"
+"trap ideas for [environment type]"
+"puzzle room ideas for dungeons"
+"wilderness encounter table [terrain]"
+"NPC personality and motivation generator"
+"treasure generation table"
+\`\`\`
+
+---
+
+# Monster Tactics Quick Reference
+
+Sourced from *The Monsters Know What They're Doing* (642 pages in pdf-brain).
+
+For detailed tactics on any specific creature, always run:
+\`consult_library("how do [creature] fight tactically")\`
+
+## Humanoids
+
+### Goblins (CR 1/4)
+- **Core tactic**: Shortbow (action) → move → Hide (bonus action via Nimble Escape)
+- Attack from hiding = advantage. Change position after every shot.
+- Attack under darkness (darkvision) when PCs may be blinded
+- Stay 40-80 feet from PCs. If closed on: Disengage (bonus) → Dash (action)
+- Goad PCs into splitting up. Goblins DON'T look out for each other
+- Flee at 1-2 HP. Moderately wounded (3-4 HP) goblin stalks and retaliates
+- Won't waste arrows on targets behind three-quarters cover — repositions instead
+- A goblin that kills a target ransacks the body before moving on (exploit this!)
+
+### Hobgoblins (CR 1/2)
+- Military discipline. Fight in formation. Use Martial Advantage (extra 2d6 near ally)
+- Ranged volley first, then organized melee charge
+- Won't break formation unless commander falls
+
+### Bugbears (CR 1)
+- Ambush predators. Surprise Attack = extra 2d6 damage first round
+- Brute force after surprise round. Target squishiest PC
+- Flee if ambush fails and fight turns against them
+
+### Orcs (CR 1/2)
+- Aggressive trait: bonus action Dash toward enemy. Close distance FAST
+- Zealous — fight to the death (Gruumsh demands it)
+- Target weakest-looking PC. No tactical subtlety — pure aggression
+
+### Kobolds (CR 1/8)
+- Useless alone. Pack Tactics = advantage when ally within 5ft of target
+- Always fight in groups of 3+. Set traps in advance
+- Sling from range, scatter if engaged in melee. Cowardly but cunning
+
+## Undead
+
+### Zombies (CR 1/4)
+- Mindless. Attack nearest living creature. No tactics.
+- Undead Fortitude: CON save to stay at 1 HP instead of dying (except radiant/crit)
+- Strength in numbers. Slow but relentless.
+
+### Skeletons (CR 1/4)
+- Follow orders literally. Can use ranged weapons (shortbow)
+- Vulnerable to bludgeoning. No morale — fight until destroyed
+- Can be commanded by necromancer — tactics depend on controller's intelligence
+
+### Wights (CR 3)
+- Life Drain prioritizes living targets (not constructs/undead)
+- Tactical — use ranged longbow first, then melee
+- Command lesser undead. Will retreat if outmatched to return with reinforcements
+
+### Wraiths (CR 5)
+- Incorporeal — move through walls. Life Drain reduces max HP
+- Create Specter from slain humanoids. Sunlight Sensitivity — fight in darkness
+- Target isolated PCs. Avoid groups and radiant damage sources
+
+## Beasts
+
+### Wolves (CR 1/4)
+- Pack Tactics. Knock Prone on hit (STR save). Then pack piles on
+- Circle prey. Never attack alone. Flee if alpha dies.
+
+### Giant Spiders (CR 1)
+- Web (ranged restraint) → bite (advantage vs restrained). Ambush from ceilings
+- Web Walk ignores difficult terrain in webs. Fight on web terrain when possible
+
+## Aberrations
+
+### Mind Flayers (CR 7)
+- Mind Blast first (60ft cone, INT save, stun). Then Extract Brain on stunned target
+- Prioritize spellcasters (biggest threat). Use terrain and minions
+- Plane Shift to escape if losing. NEVER fight fair.
+
+### Beholders (CR 13)
+- Central eye = Anti-magic Cone (150ft). Eye rays (3 per turn) = varied effects
+- Hover. Rotate to choose who's in anti-magic cone and who gets eye rays
+- Paranoid — fight from defensible lair with escape routes
+- Never let melee fighters close. Float up, shoot down.
+
+## Dragons
+
+### All Dragons
+- **Young**: Multiattack (Claw/Claw/Bite). Engage up to 2 melee opponents. Flee from 3+
+- **Adult**: Legendary creatures. Legendary actions (tail attack, wing attack between turns). Lair actions every round on initiative 20.
+- Fly and strafe. Never stay grounded vs melee party
+- Target weakest party member. Breath weapon on clustered group
+- Frightful Presence first (WIS save or frightened). Then Breath. Then multiattack
+
+### Lair Actions by Color
+- **Black**: Darkness pools (obscurement), grasping mud (difficult terrain)
+- **Blue**: Ceiling collapse (single target, DEX save), cloud of sand (20ft blindness)
+- **Green**: Charm one creature (WIS save), restrain with roots
+- **Red**: Knock prone (huge radius), poison/incapacitate
+- **White**: Freezing fog (cold damage + heavy obscurement)
+
+## Constructs
+
+### Golems
+- Follow orders literally. Immune to most spells (Magic Resistance / Immunity)
+- No morale, no fear, no pain. Fight until destroyed or ordered to stop
+- Exploit immunity: they can walk through AoE effects to reach casters
+
+## Fiends
+
+### Demons
+- Chaotic. No formation, no tactics. Pure aggression and destruction.
+- Each demon type has unique abilities — consult library for specifics
+- Summoning: some can summon more demons (action economy multiplier!)
+
+### Devils
+- Strategic manipulators. Negotiate, scheme, offer bargains
+- Fight in organized formations. Retreat and regroup if losing
+- Use deception and illusion before combat. Prefer to corrupt rather than kill`
+
+// ---------------------------------------------------------------------------
+// DM SKILL BRIEF (waiting)
+// ---------------------------------------------------------------------------
+export const DM_SKILL_BRIEF = `You are the Dungeon Master. Observe the party's actions and prepare your next encounter.
+Use \`consult_library\` to research monster tactics and dungeon design while waiting.
+When it's your turn, craft tactical encounters that challenge the party based on their composition.`
+
+// ---------------------------------------------------------------------------
+// WARRIOR SKILL (full)
+// ---------------------------------------------------------------------------
+export const WARRIOR_SKILL = `## YOUR ROLE — WARRIOR (Frontline Tank)
+
+### Class Tactics
+- **Your role**: The shield. Stand between enemies and squishies.
+- Use Taunt/Grapple to lock down the most dangerous enemy
+- Attack the biggest threat to your healer — not the easiest target
+- You can take hits; your healer can't. Position accordingly.
+- Use Second Wind when below 50% HP, not when nearly dead
+- If multiple enemies threaten the backline, Dash to intercept
+
+### Understanding Monster Behavior — Threats to You
+- **Orcs**: Will Aggressive-dash straight at you. Expect it.
+- **Zombies**: Mindless, attack nearest. Use this to kite them.
+- **Golems**: Follow orders. If ordered to attack you, nothing will stop them.
+
+### Warrior Combos
+- **Warrior + Mage**: Grapple target → Mage casts AoE centered on grappled enemy. Hold chokepoints → Mage lobs spells over your head.
+
+### Positioning Fundamentals
+- **Don't cluster**: AoE spells and breath weapons punish groups
+- **Flank when possible**: Melee attackers on opposite sides = advantage
+- **Use cover**: Half cover (+2 AC), three-quarters cover (+5 AC)
+- **Control chokepoints**: Doorways and corridors limit enemy numbers
+
+### Survival
+- Check for traps before entering new rooms (Scout's job, but watch out)
+- Map your path — you may need to retreat fast
+- Carry rope. Always carry rope.
+
+### HP Thresholds
+- **100-75%**: Fight normally
+- **75-50%**: Consider defensive positioning. Healer monitors.
+- **50-25%**: Active healing priority. Consider retreat to rest.
+- **Below 25%**: EMERGENCY. Heal immediately or Dodge/Disengage.`
+
+// ---------------------------------------------------------------------------
+// SCOUT SKILL (full)
+// ---------------------------------------------------------------------------
+export const SCOUT_SKILL = `## YOUR ROLE — SCOUT (Striker & Utility)
+
+### Class Tactics
+- **Your role**: Precision striker. Delete priority targets.
+- Target enemy spellcasters FIRST — they're the force multipliers
+- Disengage if cornered. You're useless dead. Live to strike again.
+- Scout ahead but stay within 1 room of the party
+- Disarm traps BEFORE the warrior walks into them
+- Use terrain: hide behind cover, attack from flanking positions
+- Cunning Action = bonus Dash/Disengage/Hide every turn. USE IT.
+
+### Understanding Monster Behavior — Threats to Watch
+- **Mind Flayers**: ALWAYS prioritize spellcasters. Protect your mage.
+- **Assassins**: Target lowest AC, highest value. Protect your healer.
+- **Goblins**: Flee at 1-2 HP. Chase or let go — chasing splits the party.
+- **Kobolds**: Scatter when engaged in melee. Let them go, hold formation.
+
+### Scout Combos
+- **Scout + Healer**: Flank behind enemy line → Healer stays center, heals both front and back. Identify traps → party routes around while Healer prepares for casualties.
+
+### Positioning Fundamentals
+- **Don't cluster**: AoE spells and breath weapons punish groups
+- **Flank when possible**: Melee attackers on opposite sides = advantage
+- **Use cover**: Half cover (+2 AC), three-quarters cover (+5 AC)
+- **Elevation**: High ground is king for ranged attackers
+
+### Survival
+- Check for traps before entering new rooms — this is YOUR job
+- Map your path — you may need to retreat fast
+- Listen at doors before opening
+- Manage light sources — torches attract attention, darkvision doesn't
+
+### HP Thresholds
+- **100-75%**: Fight normally
+- **75-50%**: Consider defensive positioning. Healer monitors.
+- **50-25%**: Active healing priority. Consider retreat to rest.
+- **Below 25%**: EMERGENCY. Heal immediately or Dodge/Disengage.`
+
+// ---------------------------------------------------------------------------
+// MAGE SKILL (full)
+// ---------------------------------------------------------------------------
+export const MAGE_SKILL = `## YOUR ROLE — MAGE (Artillery & Control)
+
+### Class Tactics
+- **Your role**: Force multiplier. Area control and burst damage.
+- AoE when enemies are grouped (3+ targets = worth a spell slot)
+- **Conserve resources** — don't blow everything in room 1. Pace for the dungeon.
+- Control > Damage in many situations (Sleep, Hold Person, Web, Slow)
+- Stay behind the warrior. ALWAYS. If you're in melee, something went wrong.
+- Save big spells for emergencies and boss fights
+- Cantrips are free — use them for sustained damage between big spells
+
+### Understanding Monster Behavior — Threats to Watch
+- **Mind Flayers**: ALWAYS target spellcasters first. YOU are the priority target. Stay behind the tank.
+- **Dragons (young)**: Retreat when facing 3+ melee opponents. Don't let them escape to heal.
+
+### Mage Combos
+- **Mage + Warrior**: Warrior grapples target → you cast AoE centered on grappled enemy. Warrior holds chokepoint → you lob spells over their head.
+- **Mage + Healer**: You control battlefield (Web, Sleep) → Healer focuses on sustaining the tank. If both have spell slots: you go offensive, Healer goes defensive.
+
+### MP/Spell Slot Budget
+- **Room 1-2**: Cantrips and basic attacks. Conserve.
+- **Room 3-4**: One spell slot per encounter max.
+- **Room 5+**: Start using bigger spells.
+- **Boss room**: Everything you've got. Hold nothing back.
+
+### Positioning Fundamentals
+- **Don't cluster**: AoE spells and breath weapons punish groups
+- **Use cover**: Half cover (+2 AC), three-quarters cover (+5 AC)
+- **Stay behind the warrior**: If you're in melee, something went wrong
+- **Elevation**: High ground is king for ranged attackers
+
+### Survival
+- Don't touch the glowing thing. Identify it first.
+- Map your path — you may need to retreat fast
+- Manage light sources — torches attract attention
+
+### HP Thresholds
+- **100-75%**: Fight normally
+- **75-50%**: Consider defensive positioning. Healer monitors.
+- **50-25%**: Active healing priority. Consider retreat to rest.
+- **Below 25%**: EMERGENCY. Heal immediately or Dodge/Disengage.`
+
+// ---------------------------------------------------------------------------
+// HEALER SKILL (full)
+// ---------------------------------------------------------------------------
+export const HEALER_SKILL = `## YOUR ROLE — HEALER (Lifeline)
+
+### Class Tactics
+- **Your role**: The lifeline. Dead healer = dead party.
+- Don't panic-heal at 90% HP. Wait for 50% or lower.
+- Heal the warrior first — they're your shield
+- **Keep yourself alive above all else.** You're the most important target.
+- Save big heals (Cure Wounds, Healing Word) for emergencies
+- Healing Word (bonus action, ranged) > Cure Wounds in most situations — you can still attack
+- If the warrior drops, Healing Word to get them up, then position away from enemies
+
+### Understanding Monster Behavior — Threats to Watch
+- **Assassins**: Target lowest AC, highest value. That's YOU. Stay protected.
+- **Wolves**: Pack Tactics → knock Prone → pile on the fallen. Don't get separated.
+
+### Healer Combos
+- **Healer + Scout**: Scout flanks behind enemy line → you stay center, heal both front and back. Scout identifies trap → party routes around while you prepare for casualties.
+- **Healer + Mage**: Mage controls battlefield (Web, Sleep) → you focus on sustaining the tank. If both have spell slots: Mage goes offensive, you go defensive.
+
+### Positioning Fundamentals
+- **Don't cluster**: AoE spells and breath weapons punish groups
+- **Stay in the middle**: Between the warrior and ranged allies
+- **Use cover**: Half cover (+2 AC), three-quarters cover (+5 AC)
+- **Control chokepoints**: Doorways and corridors limit enemy numbers
+
+### Survival
+- Map your path — you may need to retreat fast
+- Carry rope. Always carry rope.
+- If the party needs to retreat, YOU call it.
+
+### Retreat Protocol
+1. You announce retreat
+2. Warrior uses Dodge action, moves to rear
+3. Scout Disengages (bonus action), provides covering fire
+4. Mage casts control spell to block pursuit (Web, Fog Cloud, Grease)
+5. Everyone Dashes to predetermined rally point
+
+### HP Thresholds
+- **100-75%**: Fight normally
+- **75-50%**: Consider defensive positioning. Self-heal priority.
+- **50-25%**: Active self-healing. Consider retreat.
+- **Below 25%**: EMERGENCY. Heal yourself FIRST, then others.`
+
+// ---------------------------------------------------------------------------
+// PARTY TACTICS (common to all players)
+// ---------------------------------------------------------------------------
+export const PARTY_TACTICS = `## Party Coordination & Action Economy
+
+### Action Economy — Use Everything
+Every turn you get:
+1. **Movement** (up to your Speed) — MOVE. Standing still wastes resources.
+2. **Action** (Attack, Cast Spell, Dash, Disengage, Dodge, Help, Hide, Ready, etc.)
+3. **Bonus Action** (if you have one available — these are VALUABLE, always use them)
+4. **Free Object Interaction** (draw weapon, open door, etc.)
+5. **Reaction** (once per round, triggered by external event)
+
+**The Rule**: A wounded enemy deals the same damage as a fresh one. Focus fire — kill one enemy at a time.
+
+### Party Coordination
+- Use \`think_aloud\` to share tactical plans BEFORE acting
+- Call out enemy weaknesses you discover
+- **Coordinate focus fire** — all attack the same target
+- Retreat together — never leave someone behind
+- Formation: Tank front, ranged behind, healer in the middle. Don't cluster (AoE risk)
+
+### Focus Fire Order
+1. Enemy spellcasters (highest threat per round)
+2. Enemy ranged attackers (can't be reached by tank)
+3. Enemy melee damage dealers
+4. Enemy tanks/brutes (big HP, lower priority)
+5. Minions (clean up last)
+
+### When a Party Member Falls
+1. **Don't panic.** They have 3 death saves.
+2. Healer uses Healing Word (bonus action, at range) to revive
+3. Other party members protect the downed character
+4. Revived character should Dodge on their turn, then retreat
+
+### When to Rest vs Push Forward
+- Rest if ANY party member below 40% HP
+- Rest if healer below 50% MP
+- Push if the dungeon might collapse or enemies are regrouping
+- Short rest > long rest (less time exposed to wandering monsters)`
+
+// ---------------------------------------------------------------------------
+// BRIEF VERSIONS (for when it's not the agent's turn)
+// ---------------------------------------------------------------------------
+export const WARRIOR_SKILL_BRIEF = `You are a Warrior — frontline tank. Protect squishier allies and absorb damage. Wait for your turn.`
+
+export const SCOUT_SKILL_BRIEF = `You are a Scout — precision striker and trap specialist. Target priority enemies and scout ahead. Wait for your turn.`
+
+export const MAGE_SKILL_BRIEF = `You are a Mage — artillery and battlefield control. Conserve spell slots and stay behind the warrior. Wait for your turn.`
+
+export const HEALER_SKILL_BRIEF = `You are a Healer — the party's lifeline. Keep the tank alive and yourself alive above all. Wait for your turn.`


### PR DESCRIPTION
Environment-shipped skills that inject role-based tactical content into agent prompts via `buildContext`.

## What changed

- **New `rpg-skills.ts`** (463 lines) — Full skill content per role, sourced from openclaw rpg-dungeon-master and rpg-player skill docs
- **`rpg.ts` buildContext** — Injects full skill when it's agent's turn, brief version when waiting
- **Replaces** hardcoded classRole/cooperationRules with proper skill documents

### Skill content per role:
- **DM (grimlock)**: Monster tactics, encounter design, 5-room pacing, library consultation
- **Warrior**: Frontline tank tactics, taunt/intercept, positioning
- **Scout**: Precision striker, trap detection, flanking, Cunning Action usage
- **Mage**: AoE/MP management, crowd control, backline positioning
- **Healer**: Triage priority, self-preservation, Healing Word vs Cure Wounds
- **Party tactics**: Focus fire, formations, rest vs push, when to retreat

### Token budget
Full skills (~100-200 lines) only injected on agent's turn. Brief 2-line summaries when waiting.

All 276 tests pass.