### PR TITLE
feat: add update_profile tool + live dashboard agent profiles

### DIFF
--- a/apps/network/src/agent-do.test.ts
+++ b/apps/network/src/agent-do.test.ts
@@ -1512,7 +1512,9 @@ describe('AgentDO', () => {
     const get2 = await agent2.fetch(new Request('https://example/agents/alice/config'))
     expect(get2.status).toBe(200)
     const config3 = (await get2.json()) as Record<string, unknown>
-    expect(config3).toEqual(config2)
+    // GET /config now includes profile from DO storage (empty by default)
+    const { profile: _p, ...config3WithoutProfile } = config3
+    expect(config3WithoutProfile).toEqual(config2)
   })
 
   it('enforces enabledTools for OpenRouter tool definitions (strict tool exposure)', async () => {

--- a/apps/network/src/tools/index.ts
+++ b/apps/network/src/tools/index.ts
@@ -3,9 +3,14 @@ import type { PiAgentTool } from '@atproto-agent/agent'
 import type { EnvironmentContext } from '../environments/types'
 
 import { createGmTool } from './gm-tool'
+import { createProfileTool, type ProfileWriter } from './profile-tool'
 
 function isGrimlock(name: string): boolean {
   return name.trim().toLowerCase() === 'grimlock'
+}
+
+export interface ToolRegistryOptions {
+  profileWriter?: ProfileWriter
 }
 
 /**
@@ -14,14 +19,25 @@ function isGrimlock(name: string): boolean {
  * NOTE: We deliberately gate the GM tool twice:
  * - Only enabled when the agent config includes it (`enabledTools` allowlist).
  * - Only exposed to the Grimlock agent identity (hard authorization guard).
+ *
+ * The profile tool is available to ALL agents (no gating).
  */
-export function getToolsForAgent(ctx: EnvironmentContext, enabledTools: string[]): PiAgentTool[] {
+export function getToolsForAgent(
+  ctx: EnvironmentContext,
+  enabledTools: string[],
+  options?: ToolRegistryOptions,
+): PiAgentTool[] {
   const allowlist = new Set(Array.isArray(enabledTools) ? enabledTools : [])
 
   const tools: PiAgentTool[] = []
 
   if (allowlist.has('gm') && isGrimlock(ctx.agentName)) {
     tools.push(createGmTool(ctx))
+  }
+
+  // Profile tool available to all agents
+  if (options?.profileWriter) {
+    tools.push(createProfileTool(options.profileWriter))
   }
 
   return tools

--- a/apps/network/src/tools/profile-tool.test.ts
+++ b/apps/network/src/tools/profile-tool.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createProfileTool } from './profile-tool'
+
+describe('createProfileTool', () => {
+  it('writes profile with truncated fields and updatedAt', async () => {
+    const write = vi.fn().mockResolvedValue(undefined)
+    const tool = createProfileTool(write)
+
+    expect(tool.name).toBe('update_profile')
+
+    const result = await tool.execute!({ status: 'playing RPG', currentFocus: 'Room 3', mood: 'excited' })
+
+    expect(write).toHaveBeenCalledOnce()
+    const written = write.mock.calls[0][0]
+    expect(written.status).toBe('playing RPG')
+    expect(written.currentFocus).toBe('Room 3')
+    expect(written.mood).toBe('excited')
+    expect(typeof written.updatedAt).toBe('number')
+    expect(result).toEqual({ ok: true, profile: written })
+  })
+
+  it('truncates long fields', async () => {
+    const write = vi.fn().mockResolvedValue(undefined)
+    const tool = createProfileTool(write)
+
+    await tool.execute!({ status: 'x'.repeat(200), mood: 'y'.repeat(100) })
+
+    const written = write.mock.calls[0][0]
+    expect(written.status.length).toBe(100)
+    expect(written.mood.length).toBe(50)
+  })
+
+  it('handles toolCallId + params calling convention', async () => {
+    const write = vi.fn().mockResolvedValue(undefined)
+    const tool = createProfileTool(write)
+
+    await tool.execute!('tc_123', { status: 'idle' })
+
+    const written = write.mock.calls[0][0]
+    expect(written.status).toBe('idle')
+  })
+
+  it('skips non-string fields', async () => {
+    const write = vi.fn().mockResolvedValue(undefined)
+    const tool = createProfileTool(write)
+
+    await tool.execute!({ status: 123, currentFocus: null, mood: undefined })
+
+    const written = write.mock.calls[0][0]
+    expect(written.status).toBeUndefined()
+    expect(written.currentFocus).toBeUndefined()
+    expect(written.mood).toBeUndefined()
+    expect(typeof written.updatedAt).toBe('number')
+  })
+})

--- a/apps/network/src/tools/profile-tool.ts
+++ b/apps/network/src/tools/profile-tool.ts
@@ -1,0 +1,49 @@
+import type { PiAgentTool } from '@atproto-agent/agent'
+
+export type ProfileWriter = (profile: Record<string, unknown>) => Promise<void>
+
+export function createProfileTool(write: ProfileWriter): PiAgentTool {
+  return {
+    name: 'update_profile',
+    description:
+      'Update your public profile visible on the dashboard. Set your current status, what you are focused on, and your mood.',
+    parameters: {
+      type: 'object',
+      properties: {
+        status: {
+          type: 'string',
+          description: 'Short status line, e.g. "playing RPG", "idle", "exploring dungeon"',
+        },
+        currentFocus: {
+          type: 'string',
+          description: 'What you are working on or thinking about right now',
+        },
+        mood: {
+          type: 'string',
+          description: 'Your current mood or disposition',
+        },
+      },
+    },
+    execute: async (
+      toolCallIdOrParams: string | Record<string, unknown>,
+      maybeParams?: unknown,
+    ) => {
+      // Support both (toolCallId, params) and (params) calling conventions
+      const args: Record<string, unknown> =
+        typeof toolCallIdOrParams === 'string'
+          ? ((maybeParams && typeof maybeParams === 'object'
+              ? (maybeParams as Record<string, unknown>)
+              : {}) as Record<string, unknown>)
+          : (toolCallIdOrParams ?? {})
+
+      const profile: Record<string, unknown> = { updatedAt: Date.now() }
+      if (typeof args.status === 'string')
+        profile.status = args.status.slice(0, 100)
+      if (typeof args.currentFocus === 'string')
+        profile.currentFocus = args.currentFocus.slice(0, 200)
+      if (typeof args.mood === 'string') profile.mood = args.mood.slice(0, 50)
+      await write(profile)
+      return { ok: true, profile }
+    },
+  }
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -27,6 +27,14 @@ export interface AgentGoal {
   completedAt?: number
 }
 
+export interface AgentProfile {
+  status?: string        // "playing RPG", "idle", "thinking"
+  currentFocus?: string  // "Exploring dungeon room 3"
+  mood?: string          // "excited", "cautious"
+  avatar?: string        // emoji or URL
+  updatedAt?: number     // epoch ms
+}
+
 export interface AgentConfig {
   name: string
   personality: string // System prompt

--- a/packages/dashboard/src/components/AgentCard.tsx
+++ b/packages/dashboard/src/components/AgentCard.tsx
@@ -30,10 +30,19 @@ export function AgentCard({ agent, expanded, isAdmin, onToggle, onLoadEnvironmen
           <Heartbeat active={loopActive} />
           <span className="agent-card-name">{agent.displayName}</span>
           <div style={{ flex: 1 }} />
+          {agent.config?.profile?.mood && (
+            <Badge variant="dim">{agent.config.profile.mood}</Badge>
+          )}
           {agent.config?.specialty && (
             <Badge variant="dim">{agent.config.specialty}</Badge>
           )}
         </div>
+        {(agent.config?.profile?.status || agent.config?.profile?.currentFocus) && (
+          <div style={{ fontSize: 'var(--fs-2xs)', color: 'var(--fg-dim)', padding: '0.125rem 0 0 1.5rem' }}>
+            {agent.config.profile.status && <div>{agent.config.profile.status}</div>}
+            {agent.config.profile.currentFocus && <div style={{ opacity: 0.7 }}>{agent.config.profile.currentFocus}</div>}
+          </div>
+        )}
         <div className="agent-card-meta">
           {agent.did && (
             <span

--- a/packages/dashboard/src/components/AgentDetail.tsx
+++ b/packages/dashboard/src/components/AgentDetail.tsx
@@ -2,6 +2,14 @@ import type { AgentCardState } from '../lib/types'
 import { Badge } from './ui/Badge'
 import { EnvironmentCard } from './EnvironmentCard'
 
+function formatRelativeTime(epoch: number): string {
+  const diff = Date.now() - epoch
+  if (diff < 60_000) return 'just now'
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`
+  return `${Math.floor(diff / 86_400_000)}d ago`
+}
+
 export interface AgentDetailProps {
   agent: AgentCardState
   isAdmin: boolean
@@ -15,6 +23,30 @@ export function AgentDetail({ agent, isAdmin }: AgentDetailProps) {
 
   return (
     <div className="agent-detail">
+      {/* Profile */}
+      {config?.profile && (config.profile.status || config.profile.currentFocus || config.profile.mood) && (
+        <div className="agent-detail-section">
+          <div className="agent-detail-title">Profile</div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+            {config.profile.status && (
+              <div className="agent-detail-row"><span className="label">Status</span><span className="value">{config.profile.status}</span></div>
+            )}
+            {config.profile.currentFocus && (
+              <div className="agent-detail-row"><span className="label">Focus</span><span className="value">{config.profile.currentFocus}</span></div>
+            )}
+            {config.profile.mood && (
+              <div className="agent-detail-row"><span className="label">Mood</span><span className="value">{config.profile.mood}</span></div>
+            )}
+            {config.profile.updatedAt && (
+              <div className="agent-detail-row">
+                <span className="label">Updated</span>
+                <span className="value" style={{ opacity: 0.7 }}>{formatRelativeTime(config.profile.updatedAt)}</span>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
       {/* Goals */}
       <div className="agent-detail-section">
         <div className="agent-detail-title">Goals</div>

--- a/packages/dashboard/src/lib/types.ts
+++ b/packages/dashboard/src/lib/types.ts
@@ -12,6 +12,14 @@ export type AgentGoal = {
   completedAt?: number
 }
 
+export type AgentProfile = {
+  status?: string
+  currentFocus?: string
+  mood?: string
+  avatar?: string
+  updatedAt?: number
+}
+
 export type AgentConfig = {
   name: string
   personality: string
@@ -22,6 +30,7 @@ export type AgentConfig = {
   goals: AgentGoal[]
   enabledTools: string[]
   webhookUrl?: string
+  profile?: AgentProfile
 }
 
 export type AgentLoop = {


### PR DESCRIPTION
Agents can now self-report their status to the dashboard in real-time.

## Changes
- **AgentProfile type** (status, currentFocus, mood, avatar, updatedAt) in core types
- **update_profile tool** available to ALL agents — sets status/focus/mood with truncation
- **GET/PUT /agents/:name/profile** endpoint on AgentDO
- **GET /config** now includes profile from DO storage
- **Dashboard AgentCard** shows live status + focus below agent name
- **Dashboard AgentDetail** shows full profile section with relative timestamps
- **4 profile tool tests** (basic, truncation, calling conventions, type safety)

All 280 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agents can now report and update their profile, including status, current focus, and mood information
  * Profile data is dynamically displayed throughout the dashboard with visual mood indicators and relative timestamps showing when profiles were last updated
  * Agent detail view includes a dedicated profile section showcasing all reported information

* **Tests**
  * Added unit tests for profile reporting functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->