### PR TITLE
feat: phase-based tool restriction for RPG setup

### DIFF
--- a/apps/network/src/environments/phase-machine.test.ts
+++ b/apps/network/src/environments/phase-machine.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  createPhaseMachine,
+  createRpgSetupPhaseMachine,
+  serializePhaseMachine,
+  deserializePhaseMachine,
+  type Phase,
+} from './phase-machine'
+
+describe('PhaseMachine', () => {
+  it('creates a machine and tracks current phase', () => {
+    const phases: Record<string, Phase> = {
+      a: { name: 'a', activeAgent: 'alice', availableTools: ['t1'], prompt: 'do A', transitionOn: 'act_a', nextPhase: 'b' },
+      b: { name: 'b', activeAgent: 'bob', availableTools: ['t2'], prompt: 'do B', transitionOn: 'act_b', nextPhase: 'done' },
+    }
+    const machine = createPhaseMachine({ phases, initialPhase: 'a' })
+
+    expect(machine.currentPhase).toBe('a')
+    expect(machine.getActiveAgent()).toBe('alice')
+    expect(machine.getPhasePrompt()).toBe('do A')
+    expect(machine.isActiveAgent('alice')).toBe(true)
+    expect(machine.isActiveAgent('bob')).toBe(false)
+  })
+
+  it('returns available tools only for the active agent', () => {
+    const phases: Record<string, Phase> = {
+      a: { name: 'a', activeAgent: 'alice', availableTools: ['rpg'], prompt: '', transitionOn: 'act', nextPhase: 'b' },
+      b: { name: 'b', activeAgent: 'bob', availableTools: ['rpg', 'extra'], prompt: '', transitionOn: 'act', nextPhase: '' },
+    }
+    const machine = createPhaseMachine({ phases, initialPhase: 'a' })
+
+    expect(machine.getAvailableTools('alice')).toEqual(['rpg'])
+    expect(machine.getAvailableTools('bob')).toEqual([])
+    expect(machine.getAvailableTools('nobody')).toEqual([])
+  })
+
+  it('advances to the next phase', () => {
+    const phases: Record<string, Phase> = {
+      a: { name: 'a', activeAgent: 'alice', availableTools: ['t1'], prompt: '', transitionOn: 'act', nextPhase: 'b' },
+      b: { name: 'b', activeAgent: 'bob', availableTools: ['t2'], prompt: '', transitionOn: 'act', nextPhase: 'done' },
+    }
+    const machine = createPhaseMachine({ phases, initialPhase: 'a' })
+
+    const next = machine.advance({})
+    expect(next).toBe('b')
+    expect(machine.currentPhase).toBe('b')
+    expect(machine.getActiveAgent()).toBe('bob')
+
+    const next2 = machine.advance({})
+    expect(next2).toBe('done')
+    expect(machine.isComplete()).toBe(true)
+  })
+
+  it('supports function-based nextPhase', () => {
+    const phases: Record<string, Phase> = {
+      start: {
+        name: 'start',
+        activeAgent: 'dm',
+        availableTools: ['rpg'],
+        prompt: '',
+        transitionOn: 'act',
+        nextPhase: (result: any) => result?.good ? 'good_end' : 'bad_end',
+      },
+      good_end: { name: 'good_end', activeAgent: 'dm', availableTools: [], prompt: '', transitionOn: '', nextPhase: '' },
+      bad_end: { name: 'bad_end', activeAgent: 'dm', availableTools: [], prompt: '', transitionOn: '', nextPhase: '' },
+    }
+    const machine = createPhaseMachine({ phases, initialPhase: 'start' })
+
+    machine.advance({ good: true })
+    expect(machine.currentPhase).toBe('good_end')
+  })
+
+  it('isComplete returns true when phase does not exist', () => {
+    const machine = createPhaseMachine({ phases: {}, initialPhase: 'nonexistent' })
+    expect(machine.isComplete()).toBe(true)
+  })
+})
+
+describe('createRpgSetupPhaseMachine', () => {
+  it('creates phases for all players with correct transitions', () => {
+    const players = ['slag', 'snarl', 'swoop']
+    const machine = createRpgSetupPhaseMachine(players, 2, 'grimlock')
+
+    // Should start with narrate for first player
+    expect(machine.currentPhase).toBe('setup_narrate_slag_0')
+    expect(machine.getActiveAgent()).toBe('grimlock')
+    expect(machine.getAvailableTools('grimlock')).toEqual(['rpg'])
+    expect(machine.getAvailableTools('slag')).toEqual([])
+
+    // Advance: narrate_slag_0 → respond_slag_0
+    machine.advance({})
+    expect(machine.currentPhase).toBe('setup_respond_slag_0')
+    expect(machine.getActiveAgent()).toBe('slag')
+    expect(machine.getAvailableTools('slag')).toEqual(['rpg'])
+    expect(machine.getAvailableTools('grimlock')).toEqual([])
+
+    // Advance: respond_slag_0 → narrate_slag_1
+    machine.advance({})
+    expect(machine.currentPhase).toBe('setup_narrate_slag_1')
+    expect(machine.getActiveAgent()).toBe('grimlock')
+
+    // Advance: narrate_slag_1 → respond_slag_1
+    machine.advance({})
+    expect(machine.currentPhase).toBe('setup_respond_slag_1')
+    expect(machine.getActiveAgent()).toBe('slag')
+
+    // Advance: respond_slag_1 → narrate_snarl_0 (next player)
+    machine.advance({})
+    expect(machine.currentPhase).toBe('setup_narrate_snarl_0')
+    expect(machine.getActiveAgent()).toBe('grimlock')
+
+    // Fast-forward through snarl
+    machine.advance({}); machine.advance({}); machine.advance({}); machine.advance({})
+    expect(machine.currentPhase).toBe('setup_narrate_swoop_0')
+
+    // Fast-forward through swoop
+    machine.advance({}); machine.advance({}); machine.advance({}); machine.advance({})
+    expect(machine.currentPhase).toBe('setup_finalize')
+    expect(machine.getActiveAgent()).toBe('grimlock')
+
+    // Finalize → complete
+    machine.advance({})
+    expect(machine.currentPhase).toBe('complete')
+    expect(machine.isComplete()).toBe(true)
+  })
+
+  it('handles single player', () => {
+    const machine = createRpgSetupPhaseMachine(['slag'], 1, 'grimlock')
+    expect(machine.currentPhase).toBe('setup_narrate_slag_0')
+
+    machine.advance({}) // → respond_slag_0
+    expect(machine.currentPhase).toBe('setup_respond_slag_0')
+
+    machine.advance({}) // → finalize
+    expect(machine.currentPhase).toBe('setup_finalize')
+
+    machine.advance({}) // → complete
+    expect(machine.isComplete()).toBe(true)
+  })
+
+  it('handles empty player list', () => {
+    const machine = createRpgSetupPhaseMachine([], 2, 'grimlock')
+    expect(machine.currentPhase).toBe('setup_finalize')
+  })
+})
+
+describe('serialize/deserialize', () => {
+  it('round-trips a phase machine', () => {
+    const machine = createRpgSetupPhaseMachine(['slag', 'snarl'], 1, 'grimlock')
+    machine.advance({}) // → respond_slag_0
+
+    const data = serializePhaseMachine(machine)
+    expect(data.currentPhase).toBe('setup_respond_slag_0')
+
+    const restored = deserializePhaseMachine(data)
+    expect(restored.currentPhase).toBe('setup_respond_slag_0')
+    expect(restored.getActiveAgent()).toBe('slag')
+    expect(restored.getAvailableTools('slag')).toEqual(['rpg'])
+    expect(restored.getAvailableTools('grimlock')).toEqual([])
+
+    // Continue advancing the restored machine
+    restored.advance({}) // → narrate_snarl_0
+    expect(restored.currentPhase).toBe('setup_narrate_snarl_0')
+    expect(restored.getActiveAgent()).toBe('grimlock')
+  })
+})
+
+describe('tool filtering integration', () => {
+  it('non-active agents get empty tool list', () => {
+    const machine = createRpgSetupPhaseMachine(['slag', 'snarl', 'swoop'], 2, 'grimlock')
+
+    // During narrate phase, only grimlock gets tools
+    expect(machine.getAvailableTools('grimlock')).toEqual(['rpg'])
+    expect(machine.getAvailableTools('slag')).toEqual([])
+    expect(machine.getAvailableTools('snarl')).toEqual([])
+    expect(machine.getAvailableTools('swoop')).toEqual([])
+  })
+
+  it('only correct player can act during respond phase', () => {
+    const machine = createRpgSetupPhaseMachine(['slag', 'snarl', 'swoop'], 2, 'grimlock')
+    machine.advance({}) // → respond_slag_0
+
+    expect(machine.getAvailableTools('slag')).toEqual(['rpg'])
+    expect(machine.getAvailableTools('snarl')).toEqual([])
+    expect(machine.getAvailableTools('swoop')).toEqual([])
+    expect(machine.getAvailableTools('grimlock')).toEqual([])
+  })
+
+  it('full setup flow end-to-end', () => {
+    const players = ['slag', 'snarl', 'swoop']
+    const machine = createRpgSetupPhaseMachine(players, 2, 'grimlock')
+    const transitions: string[] = [machine.currentPhase]
+
+    while (!machine.isComplete()) {
+      machine.advance({})
+      transitions.push(machine.currentPhase)
+    }
+
+    // Expected: for each player, 2x (narrate + respond), then finalize, then complete
+    // 3 players * 2 exchanges * 2 phases + finalize + complete = 14 total transitions
+    expect(transitions).toHaveLength(14)
+    expect(transitions[0]).toBe('setup_narrate_slag_0')
+    expect(transitions[transitions.length - 2]).toBe('setup_finalize')
+    expect(transitions[transitions.length - 1]).toBe('complete')
+
+    // Verify pattern: narrate → respond → narrate → respond → ... → finalize → complete
+    for (let i = 0; i < transitions.length - 2; i++) {
+      const t = transitions[i]!
+      if (t.startsWith('setup_narrate_')) {
+        expect(transitions[i + 1]).toMatch(/^setup_respond_/)
+      }
+    }
+  })
+})

--- a/apps/network/src/environments/phase-machine.ts
+++ b/apps/network/src/environments/phase-machine.ts
@@ -1,0 +1,222 @@
+/**
+ * Phase-based tool restriction state machine.
+ *
+ * Each phase declares exactly which agent can act and which tools are available.
+ * All other tools are suppressed — not hinted away, structurally removed.
+ *
+ * This replaces behavioral prompting ("please use X") with structural constraints.
+ */
+
+export interface Phase {
+  /** Unique phase name, e.g. "setup_narrate_slag" */
+  name: string
+  /** Agent name or role that can act in this phase */
+  activeAgent: string
+  /** ONLY these tools exist for the active agent in this phase */
+  availableTools: string[]
+  /** Context prompt injected for this phase */
+  prompt: string
+  /** Tool call command that triggers transition (e.g. "setup_narrate") */
+  transitionOn: string
+  /** Next phase name, or a function that computes it from the tool call result */
+  nextPhase: string | ((result: unknown) => string)
+}
+
+export interface PhaseMachine {
+  phases: Record<string, Phase>
+  currentPhase: string
+  /** Advance the machine after a tool call completes. Returns the new phase name. */
+  advance(toolCallResult: unknown): string | null
+  /** Get available tools for a given agent in the current phase. Returns null if no restriction. */
+  getAvailableTools(agentName: string): string[] | null
+  /** Get the active agent for the current phase */
+  getActiveAgent(): string
+  /** Get the prompt context for the current phase */
+  getPhasePrompt(): string
+  /** Check if a given agent is the active agent in the current phase */
+  isActiveAgent(agentName: string): boolean
+  /** Get current phase object */
+  getCurrentPhase(): Phase | null
+  /** Check if the machine has completed (no current phase or phase doesn't exist) */
+  isComplete(): boolean
+}
+
+export interface PhaseMachineConfig {
+  phases: Record<string, Phase>
+  initialPhase: string
+}
+
+/**
+ * Create a phase machine from config.
+ */
+export function createPhaseMachine(config: PhaseMachineConfig): PhaseMachine {
+  const { phases } = config
+  let currentPhase = config.initialPhase
+
+  return {
+    phases,
+    get currentPhase() {
+      return currentPhase
+    },
+    set currentPhase(value: string) {
+      currentPhase = value
+    },
+
+    advance(toolCallResult: unknown): string | null {
+      const phase = phases[currentPhase]
+      if (!phase) return null
+
+      const next =
+        typeof phase.nextPhase === 'function'
+          ? phase.nextPhase(toolCallResult)
+          : phase.nextPhase
+
+      if (next && phases[next]) {
+        currentPhase = next
+        return next
+      }
+
+      // If next is a string but not in phases, machine is complete
+      if (typeof next === 'string' && next !== '') {
+        currentPhase = next
+        return next
+      }
+
+      return null
+    },
+
+    getAvailableTools(agentName: string): string[] | null {
+      const phase = phases[currentPhase]
+      if (!phase) return null
+
+      // Only the active agent gets tools; everyone else gets nothing
+      if (phase.activeAgent !== agentName) {
+        return []
+      }
+      return [...phase.availableTools]
+    },
+
+    getActiveAgent(): string {
+      return phases[currentPhase]?.activeAgent ?? ''
+    },
+
+    getPhasePrompt(): string {
+      return phases[currentPhase]?.prompt ?? ''
+    },
+
+    isActiveAgent(agentName: string): boolean {
+      return phases[currentPhase]?.activeAgent === agentName
+    },
+
+    getCurrentPhase(): Phase | null {
+      return phases[currentPhase] ?? null
+    },
+
+    isComplete(): boolean {
+      return !phases[currentPhase]
+    },
+  }
+}
+
+/**
+ * Build the RPG setup phase machine for a given player list.
+ * 
+ * Flow: for each player, DM narrates → player responds, repeated maxExchanges times.
+ * After all players: DM finalizes.
+ */
+export function createRpgSetupPhaseMachine(
+  playerAgents: string[],
+  maxExchanges: number = 2,
+  dmAgent: string = 'grimlock'
+): PhaseMachine {
+  const phases: Record<string, Phase> = {}
+
+  for (let pIdx = 0; pIdx < playerAgents.length; pIdx++) {
+    const agent = playerAgents[pIdx]!
+    for (let ex = 0; ex < maxExchanges; ex++) {
+      const narrateName = `setup_narrate_${agent}_${ex}`
+      const respondName = `setup_respond_${agent}_${ex}`
+
+      // Determine next phase after respond
+      let nextAfterRespond: string
+      if (ex + 1 < maxExchanges) {
+        // More exchanges for this player
+        nextAfterRespond = `setup_narrate_${agent}_${ex + 1}`
+      } else if (pIdx + 1 < playerAgents.length) {
+        // Move to next player
+        nextAfterRespond = `setup_narrate_${playerAgents[pIdx + 1]}_0`
+      } else {
+        // All players done, finalize
+        nextAfterRespond = 'setup_finalize'
+      }
+
+      phases[narrateName] = {
+        name: narrateName,
+        activeAgent: dmAgent,
+        availableTools: ['rpg'],
+        prompt:
+          `SETUP PHASE — Interview ${agent} about their backstory (exchange ${ex + 1}/${maxExchanges}).\n` +
+          `Call: { "command": "setup_narrate", "target": "${agent}", "message": "<your question>" }`,
+        transitionOn: 'setup_narrate',
+        nextPhase: respondName,
+      }
+
+      phases[respondName] = {
+        name: respondName,
+        activeAgent: agent,
+        availableTools: ['rpg'],
+        prompt:
+          `SETUP PHASE — Respond to the DM's backstory question.\n` +
+          `Call: { "command": "setup_respond", "message": "<your response>" }`,
+        transitionOn: 'setup_respond',
+        nextPhase: nextAfterRespond,
+      }
+    }
+  }
+
+  // Finalize phase
+  phases['setup_finalize'] = {
+    name: 'setup_finalize',
+    activeAgent: dmAgent,
+    availableTools: ['rpg'],
+    prompt:
+      `SETUP PHASE — All backstory interviews are complete. Finalize the backstories.\n` +
+      `Call: { "command": "setup_finalize", "backstories": { "<agent>": "<backstory>" } }`,
+    transitionOn: 'setup_finalize',
+    nextPhase: 'complete',
+  }
+
+  const initialPhase = playerAgents.length > 0
+    ? `setup_narrate_${playerAgents[0]}_0`
+    : 'setup_finalize'
+
+  return createPhaseMachine({ phases, initialPhase })
+}
+
+/**
+ * Serialize a phase machine to plain object for storage (e.g. in game state JSON).
+ */
+export function serializePhaseMachine(machine: PhaseMachine): { currentPhase: string; phasesSnapshot: Record<string, Omit<Phase, 'nextPhase'> & { nextPhase: string }> } {
+  // We can't serialize functions, so for RPG setup the nextPhase is always a string
+  const snapshot: Record<string, any> = {}
+  for (const [key, phase] of Object.entries(machine.phases)) {
+    snapshot[key] = {
+      ...phase,
+      nextPhase: typeof phase.nextPhase === 'function' ? '' : phase.nextPhase,
+    }
+  }
+  return {
+    currentPhase: machine.currentPhase,
+    phasesSnapshot: snapshot,
+  }
+}
+
+/**
+ * Deserialize a phase machine from stored state.
+ */
+export function deserializePhaseMachine(data: { currentPhase: string; phasesSnapshot: Record<string, Phase> }): PhaseMachine {
+  return createPhaseMachine({
+    phases: data.phasesSnapshot,
+    initialPhase: data.currentPhase,
+  })
+}

--- a/apps/network/src/environments/types.ts
+++ b/apps/network/src/environments/types.ts
@@ -1,4 +1,5 @@
 import type { PiAgentTool } from '@atproto-agent/agent'
+import type { PhaseMachine } from './phase-machine'
 
 export type ToolCall = {
   name: string
@@ -36,4 +37,8 @@ export interface AgentEnvironment {
     next: string,
     detail: Record<string, unknown>
   ) => void | Promise<void>
+  /** Return the current phase machine, if one is active */
+  getPhaseMachine?: (ctx: EnvironmentContext) => PhaseMachine | null | Promise<PhaseMachine | null>
+  /** Return allowed tools for an agent in the current phase, or null for no restriction */
+  getPhaseTools?: (agentName: string, ctx: EnvironmentContext) => string[] | null | Promise<string[] | null>
 }


### PR DESCRIPTION
## What

Replaces auto-play overrides with a **PhaseMachine** state machine. Each phase exposes exactly ONE active agent and a tool whitelist — tools not in the whitelist don't exist in API calls.

## The pattern

```
setup_narrate_slag (DM only, tool: setup_narrate)
  → setup_respond_slag (slag only, tool: setup_respond)
  → setup_narrate_snarl (DM only, tool: setup_narrate)
  → setup_respond_snarl (snarl only, tool: setup_respond)
  → setup_narrate_swoop (DM only, tool: setup_narrate)
  → setup_respond_swoop (swoop only, tool: setup_respond)
  → setup_finalize (DM only, tool: setup_finalize)
  → gameplay (full toolset)
```

## What changed

- **New:** `phase-machine.ts` — generic `PhaseMachine` with serialization for game state persistence
- **rpg.ts** — setup uses phase machine; `buildContext` injects phase-specific prompts; **deleted `getSetupOverrideActions`**
- **types.ts** — `getPhaseMachine()` and `getPhaseTools()` on `AgentEnvironment` interface
- **agent.ts** — queries environment for phase whitelist during setup
- **agent-factory.ts** — hard gate: whitelist filters both tool definitions AND execution

## Why

Auto-play was an anti-pattern — doing work FOR the model instead of constraining the model to do the right work. Phase machine is structural enforcement. The tool doesn't exist = the model can't use it.

## Tests

12 new tests + all 324 existing tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced phase-based tool restriction to dynamically control agent capabilities across workflow phases
  * Added phase machine system for orchestrating sequential multi-agent workflows and transitions
  * Implemented RPG setup phase flow with support for multi-player interactions and phase state persistence

* **Tests**
  * Added comprehensive test coverage for phase machine functionality, transitions, and serialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->