### PR TITLE
fix(test): make pnpm test require Vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "turbo build",
     "vitest": "node ./scripts/vitest.mjs",
-    "test": "sh -c 'if command -v vitest >/dev/null 2>&1; then vitest run --passWithNoTests; else echo PASS; fi'",
+    "test": "node ./scripts/vitest.mjs run --passWithNoTests",
     "test:watch": "turbo test:watch",
     "check-types": "turbo typecheck",
     "typecheck": "turbo typecheck",

--- a/packages/core/src/pre-commit-hook.test.ts
+++ b/packages/core/src/pre-commit-hook.test.ts
@@ -1,4 +1,6 @@
-import { existsSync, readFileSync } from "node:fs"
+import { spawnSync } from "node:child_process"
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 
@@ -28,5 +30,39 @@ describe("git hooks", () => {
     expect(hasUncommentedCommand(contents, "pnpm typecheck")).toBe(true)
     expect(hasUncommentedCommand(contents, "pnpm test")).toBe(true)
   })
-})
 
+  it("root test script runs the Vitest wrapper without silent fallback", () => {
+    const repoRoot = repoRootFromHere()
+    const packageJson = JSON.parse(readFileSync(path.join(repoRoot, "package.json"), "utf8"))
+    const testScript = packageJson.scripts?.test
+
+    expect(testScript).toBe("node ./scripts/vitest.mjs run --passWithNoTests")
+    expect(testScript).not.toContain("command -v vitest")
+    expect(testScript).not.toContain("echo PASS")
+  })
+
+  it("Vitest wrapper reports missing dependencies instead of passing", () => {
+    const repoRoot = repoRootFromHere()
+    const tempRepo = mkdtempSync(path.join(tmpdir(), "atproto-agent-network-vitest-"))
+
+    try {
+      const scriptsDir = path.join(tempRepo, "scripts")
+      const wrapperPath = path.join(scriptsDir, "vitest.mjs")
+      mkdirSync(scriptsDir, { recursive: true })
+      copyFileSync(path.join(repoRoot, "scripts", "vitest.mjs"), wrapperPath)
+
+      const result = spawnSync(
+        process.execPath,
+        [wrapperPath, "run", "--passWithNoTests"],
+        { encoding: "utf8" },
+      )
+
+      expect(result.status).toBe(1)
+      expect(result.stderr).toContain("Vitest is not installed")
+      expect(result.stderr).toContain("pnpm install --frozen-lockfile")
+      expect(result.stdout).not.toContain("PASS")
+    } finally {
+      rmSync(tempRepo, { recursive: true, force: true })
+    }
+  })
+})

--- a/scripts/vitest.mjs
+++ b/scripts/vitest.mjs
@@ -1,10 +1,18 @@
 import { spawnSync } from "node:child_process"
+import { existsSync } from "node:fs"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.resolve(scriptDir, "..")
 const vitestPath = path.join(repoRoot, "node_modules", "vitest", "vitest.mjs")
+
+if (!existsSync(vitestPath)) {
+  console.error(
+    "Vitest is not installed. Run pnpm install --frozen-lockfile before running pnpm test.",
+  )
+  process.exit(1)
+}
 
 const args = process.argv.slice(2)
 const forwarded = []
@@ -42,5 +50,10 @@ if (!hasProjectArg) {
 const result = spawnSync(process.execPath, [vitestPath, ...forwarded], {
   stdio: "inherit",
 })
+
+if (result.error) {
+  console.error(`Failed to start Vitest: ${result.error.message}`)
+  process.exit(1)
+}
 
 process.exit(result.status ?? 1)


### PR DESCRIPTION
Closes #24

## Changes
- Route the root `pnpm test` script through `scripts/vitest.mjs` instead of the shell fallback.
- Make the Vitest wrapper fail with setup guidance when the local runner is missing.
- Add tooling-contract coverage for the root test script and missing-runner behavior.

## Validation
- PASS `pnpm install --frozen-lockfile`
- PASS `pnpm vitest run packages/core/src/pre-commit-hook.test.ts`
- PASS `pnpm vitest --filter @atproto-agent/core run src/pre-commit-hook.test.ts`
- PASS `pnpm --filter @atproto-agent/core test`
- PASS `git diff --check`
- PASS `pnpm lint` (no lint tasks configured)
- FAIL `pnpm test`: existing network suite failures remain in `src/index.test.ts` from missing `@cloudflare/containers/dist/lib/container`, plus existing `src/agent-do.test.ts` alarm/loop assertions.
- FAIL `pnpm typecheck`: existing `packages/agent/src/memory.ts` TS18046 errors at lines 451 and 481.
- FAIL `pnpm turbo test`: existing `@atproto-agent/agent` DTS build failure from the same `packages/agent/src/memory.ts` TS18046 errors.

## Notes
- No runtime code, Cloudflare bindings, migrations, or deployment config changed.
- Deployment and production smoke test were not run because this PR only changes local test tooling, matching the exec plan scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test script reliability with direct Node invocation and enhanced error handling for missing dependencies.

* **Tests**
  * Added integration tests to validate test script configuration and verify proper error messaging when dependencies are unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/joelhooks/atproto-agent-network/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->